### PR TITLE
Update to .NET9

### DIFF
--- a/demos/nyris.demo.Android/AndroidManifest.xml
+++ b/demos/nyris.demo.Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Nyris.Demo.Android">
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
+  <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="35" />
   <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/AppTheme"></application>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/demos/nyris.demo.Android/nyris.demo.Android.csproj
+++ b/demos/nyris.demo.Android/nyris.demo.Android.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0-android</TargetFramework>
-        <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+        <TargetFramework>net9.0-android</TargetFramework>
+        <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
         <OutputType>Exe</OutputType>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -23,9 +23,9 @@
       <ProjectReference Include="..\..\sdk\ui\nyris.ui.common\nyris.ui.common.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.4" />
-      <PackageReference Include="Xamarin.AndroidX.ConstraintLayout" Version="2.1.4.7" />
-      <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
-      <PackageReference Include="Xamarin.Google.Android.Material" Version="1.9.0.3" />
+      <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.4" />
+      <PackageReference Include="Xamarin.AndroidX.ConstraintLayout" Version="2.2.0.1" />
+      <PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
+      <PackageReference Include="Xamarin.Google.Android.Material" Version="1.12.0.1" />
     </ItemGroup>
 </Project>

--- a/demos/nyris.demo.Console/nyris.demo.Console.csproj
+++ b/demos/nyris.demo.Console/nyris.demo.Console.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Nyris.Demo.Console</RootNamespace>

--- a/demos/nyris.demo.MAUI/nyris.demo.MAUI.csproj
+++ b/demos/nyris.demo.MAUI/nyris.demo.MAUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0-android;net7.0-ios</TargetFrameworks>
+        <TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
         <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
@@ -10,6 +10,7 @@
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
 
         <!-- Display name -->
         <ApplicationTitle>nyris.demo.MAUI</ApplicationTitle>
@@ -22,16 +23,19 @@
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
         <ApplicationVersion>1</ApplicationVersion>
 
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23</SupportedOSPlatformVersion>
         <AssemblyName>Nyris.Demo.MAUI</AssemblyName>
         <PackageId>Nyris.Demo.MAUI</PackageId>
         <Authors>Nyris.Demo.MAUI</Authors>
         <Company>Nyris.Demo.MAUI</Company>
         <Product>Nyris.Demo.MAUI</Product>
+
+        <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-ios|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-ios|AnyCPU'">
       <CreatePackage>false</CreatePackage>
     </PropertyGroup>
     <ItemGroup>
@@ -53,7 +57,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -62,10 +67,12 @@
       <ProjectReference Include="..\..\sdk\ui\nyris.ui.maui\nyris.ui.maui.csproj" />
     </ItemGroup>
 
-    <!-- Workaround for https://github.com/xamarin/AndroidX/issues/742 -->
-    <ItemGroup Condition="$(TargetFramework.Contains('-android')) == true">
-        <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.7.2.2" />
-        <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.7.2.2" />
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
+        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.7.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.ConstraintLayout" Version="2.1.4.16" />
+        <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.9.2.1" />
     </ItemGroup>
 
 </Project>

--- a/demos/nyris.demo.iOS/nyris.demo.iOS.csproj
+++ b/demos/nyris.demo.iOS/nyris.demo.iOS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0-ios</TargetFramework>
+        <TargetFramework>net9.0-ios</TargetFramework>
         <OutputType>Exe</OutputType>
         <Nullable>enable</Nullable>
         <ImplicitUsings>true</ImplicitUsings>

--- a/sdk/api/nyris.api/nyris.api.csproj
+++ b/sdk/api/nyris.api/nyris.api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AssemblyName>Nyris.Api</AssemblyName>
@@ -10,10 +10,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
+      <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="Refit" Version="7.0.0" />
-      <PackageReference Include="System.Reactive" Version="6.0.0" />
+      <PackageReference Include="Refit" Version="8.0.0" />
+      <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 
 </Project>

--- a/sdk/ui/nyris.ui.Android.Camera/nyris.ui.Android.Camera.csproj
+++ b/sdk/ui/nyris.ui.Android.Camera/nyris.ui.Android.Camera.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0-android</TargetFramework>
-        <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+        <TargetFramework>net9.0-android</TargetFramework>
+        <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>Nyris.UI.Android.Camera</AssemblyName>

--- a/sdk/ui/nyris.ui.Android.Cropping/nyris.ui.Android.Cropping.csproj
+++ b/sdk/ui/nyris.ui.Android.Cropping/nyris.ui.Android.Cropping.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0-android</TargetFramework>
-        <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+        <TargetFramework>net9.0-android</TargetFramework>
+        <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>Nyris.UI.Android.Cropping</AssemblyName>

--- a/sdk/ui/nyris.ui.Android/AndroidManifest.xml
+++ b/sdk/ui/nyris.ui.Android/AndroidManifest.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.1" package="nyris.ui.android">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
+	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="35" />
 </manifest>

--- a/sdk/ui/nyris.ui.Android/nyris.ui.Android.csproj
+++ b/sdk/ui/nyris.ui.Android/nyris.ui.Android.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-        <TargetFramework>net7.0-android</TargetFramework>
-        <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+        <TargetFramework>net9.0-android</TargetFramework>
+        <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>Nyris.UI.Android</AssemblyName>
@@ -15,8 +15,8 @@
       <ProjectReference Include="..\nyris.ui.common\nyris.ui.common.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.4" />
-        <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.6.1.5" />
-        <PackageReference Include="Xamarin.AndroidX.ConstraintLayout" Version="2.1.4.7" />
+        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.7.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.ConstraintLayout" Version="2.1.4.16" />
     </ItemGroup>
 </Project>

--- a/sdk/ui/nyris.ui.common/nyris.ui.common.csproj
+++ b/sdk/ui/nyris.ui.common/nyris.ui.common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AssemblyName>Nyris.UI.Common</AssemblyName>

--- a/sdk/ui/nyris.ui.iOS/nyris.ui.iOS.csproj
+++ b/sdk/ui/nyris.ui.iOS/nyris.ui.iOS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0-ios</TargetFramework>
+        <TargetFramework>net9.0-ios</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>

--- a/sdk/ui/nyris.ui.maui/Platforms/Android/AndroidManifest.xml
+++ b/sdk/ui/nyris.ui.maui/Platforms/Android/AndroidManifest.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.1" package="nyris.ui.maui">
+	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="35" />
 </manifest>

--- a/sdk/ui/nyris.ui.maui/nyris.ui.maui.csproj
+++ b/sdk/ui/nyris.ui.maui/nyris.ui.maui.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0-android;net7.0-ios</TargetFrameworks>
+        <TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
         <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
@@ -11,7 +11,7 @@
 
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
         <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
@@ -34,10 +34,12 @@
     </ItemGroup>
 
     <ItemGroup Condition="$(TargetFramework.Contains('-android')) == true">
+        <ProjectReference Include="..\nyris.ui.Android.Camera\nyris.ui.Android.Camera.csproj" />
+        <ProjectReference Include="..\nyris.ui.Android.Cropping\nyris.ui.Android.Cropping.csproj" />
         <ProjectReference Include="..\nyris.ui.Android\nyris.ui.Android.csproj" />
-        <!-- Workaround for https://github.com/xamarin/AndroidX/issues/742 -->
-        <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.7.2.2" />
-        <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.7.2.2" />
+        <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.7.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.ConstraintLayout" Version="2.1.4.16" />
     </ItemGroup> 
     <ItemGroup Condition="$(TargetFramework.Contains('-ios')) == true">
         <ProjectReference Include="..\nyris.ui.iOS\nyris.ui.iOS.csproj" />


### PR DESCRIPTION
Update projects to net9 to allow building with net9 Android dependencies. We've encountered conflicts with packages between the Nyris-SDK and other packages that used the Xamarin.AndroidX.Activity packages, this is why we initiated the update.